### PR TITLE
fix: add appuser + ensure logs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,8 +10,12 @@
 **/.classpath
 **/.dockerignore
 **/.env
+**/.env.example
 **/.git
 **/.gitignore
+**/.gitattribute
+**/.github
+**/.idea
 **/.project
 **/.settings
 **/.toolstarget
@@ -30,5 +34,10 @@
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
+logs/
+*.log
 LICENSE
 README.md
+CONTRIBUTING.md
+README.Docker.md
+SECURITY.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-name: Python MCP Server
+name: Build MCP Server
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,5 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,15 @@ WORKDIR /app
 ## Create a non-privileged user that the app will run under.
 ## Ensure write permissions are enabled for the repository folder to allow log generation, otherwise the script will not work.
 ## See https://docs.docker.com/go/dockerfile-user-best-practices/
-#ARG UID=10001
-#RUN adduser \
-#    --disabled-password \
-#    --gecos "" \
-#    --home "/nonexistent" \
-#    --shell "/sbin/nologin" \
-#    --no-create-home \
-#    --uid "${UID}" \
-#    appuser
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
 
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
@@ -38,11 +38,15 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+RUN mkdir -p /app/logs && chown appuser:appuser /app/logs
+
 # Switch to the non-privileged user to run the application.
-#USER appuser
+USER appuser
 
 # Copy the source code into the container.
 COPY . .
+
+# RUN mkdir -p /app/logs
 
 # Expose the port that the application listens on.
 EXPOSE 3000

--- a/src/config.py
+++ b/src/config.py
@@ -30,7 +30,7 @@ class Config:
 
     # Logging
     LOGGER_NAME: str = "bitcoin_mcp_server"
-    LOG_DIR: str = "../logs"
+    LOG_DIR: str = str(Path(__file__).parent.parent / "logs")
     LOG_LEVEL: str = "INFO"
     LOGGER_BACKUP_COUNT: int = 30
     LOGGER_CONSOLE_OUTPUT: bool = True


### PR DESCRIPTION
Uncomment Dockerfile steps to create a non-privileged appuser and switch to USER appuser, and create /app/logs with correct ownership so the containerized app can write logs. Update src/config.py to use a project-relative logs path (Path(...)/"logs"). Add logs/, *.log and other metadata/docs/.github entries to .dockerignore and add logs/ to .gitignore. Also rename the GitHub Actions workflow from "Python MCP Server" to "Build MCP Server".