### PR TITLE
fix : close api client event on app shutdown

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -18,7 +18,6 @@ class Config:
     ENABLE_RETRY: bool = True
 
     # APIs Management
-
     CACHE_TTL_TIME: int = 60
     MAX_RETRIES: int = 3
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 # manually add project root to sys.path => entire repo becomes usable
 import sys
 import os
-
 ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.append(ROOT)
 
@@ -65,9 +64,12 @@ if __name__ == "__main__":
         uvicorn.run(app, host="0.0.0.0", port=args.port)
     else:
         logger.info("Server ready, starting STDIO MCP Server")
-        try:
-            mcp.run()
-        finally:
-            import asyncio
 
-            asyncio.run(close_all_api_clients())
+        import anyio
+
+        async def run():
+            try:
+                await mcp.run_stdio_async()
+            finally:
+                await close_all_api_clients()
+        anyio.run(run)


### PR DESCRIPTION
Fix the workflow when the app is shutting down and API client can't be closed or are closed in double